### PR TITLE
Add x86intrin.h when we compile on i386/x86_64 arch

### DIFF
--- a/toolchain/GNUmakefile
+++ b/toolchain/GNUmakefile
@@ -101,6 +101,11 @@ install: all
 	$(INSTALL) -m 0755 bin/$(CONFIG_TARGET_TRIPLE)-objcopy $(DESTINATION)/bin
 	@mkdir -p $(TOOLCHAIN_LIBDIR) $(TOOLCHAIN_INCDIR) $(TOOLCHAIN_SYSDIR) \
 		$(TOOLCHAIN_ARPADIR) $(TOOLCHAIN_NETINETDIR)
+	@if [  "$(CONFIG_TARGET_ARCH)" = "x86_64" \
+	    -o "$(CONFIG_TARGET_ARCH)" = "i386" ]; then \
+		$(INSTALL) -m 0644 include/x86/x86intrin.h \
+		"$(TOOLCHAIN_INCDIR)/x86intrin.h" ; \
+	fi
 	cd lib/cosmopolitan && \
 		find . -type f -exec $(INSTALL) -m 0644 \
 		"{}" "$(TOOLCHAIN_LIBDIR)/{}" \;

--- a/toolchain/include/x86/x86intrin.h
+++ b/toolchain/include/x86/x86intrin.h
@@ -1,0 +1,1 @@
+#include "cosmopolitan.h"


### PR DESCRIPTION
It's required by `mirage-crypto` which uses some `intrin` from x86_64/i386. So we make a fake one only if you compile for x86_64/i386.