### PR TITLE
Safer include

### DIFF
--- a/caml/GNUmakefile
+++ b/caml/GNUmakefile
@@ -44,7 +44,7 @@ ocaml/Makefile.config: ocaml/Makefile esperanto_sys.c
 	sed -i -e '/^char \$$2 ()\;/s/^/\/\//' ocaml/configure
 	sed -i -e '/^return \$$2 ()\;/c\return &\$$2\;' ocaml/configure
 # configure: Allow precise input of flags and libs
-	sed -i -e 's/oc_cflags="/oc_cflags="$$OC_CFLAGS /g' ocaml/configure
+	sed -i -e 's/oc_cflags="/oc_cflags="-z caml-startup $$OC_CFLAGS /g' ocaml/configure
 	sed -i -e 's/ocamlc_cflags="/ocamlc_cflags="$$OCAMLC_CFLAGS /g' ocaml/configure
 	sed -i -e 's/nativecclibs="$$cclibs $$DLLIBS"/nativecclibs="$$GLOBAL_LIBS"/g' ocaml/configure
 # runtime/Makefile: Runtime rules: don't build libcamlrun.a and import ocamlrun from the system

--- a/caml/GNUmakefile
+++ b/caml/GNUmakefile
@@ -42,7 +42,7 @@ ocaml/Makefile.config: ocaml/Makefile esperanto_sys.c
 # configure: Do not try to redefine GCC builtins (we use Cosmopolitan which
 # does not have any builtins
 	sed -i -e '/^char \$$2 ()\;/s/^/\/\//' ocaml/configure
-	sed -i -e '/^return \$$2 ()\;/c\return &\$$2\;' ocaml/configure
+	sed -i -e 's/^return \$$2 ()\;/return \&\$$2\;/' ocaml/configure
 # configure: Allow precise input of flags and libs
 	sed -i -e 's/oc_cflags="/oc_cflags="-z caml-startup $$OC_CFLAGS /g' ocaml/configure
 	sed -i -e 's/ocamlc_cflags="/ocamlc_cflags="$$OCAMLC_CFLAGS /g' ocaml/configure

--- a/caml/GNUmakefile
+++ b/caml/GNUmakefile
@@ -39,8 +39,12 @@ OC_LIBS=-nostdlib $(MAKECONF_EXTRA_LIBS)
 ocaml/Makefile.config: ocaml/Makefile esperanto_sys.c
 # configure: Do not build dynlink
 	sed -i -e 's/otherlibraries="dynlink"/otherlibraries=""/g' ocaml/configure
+# configure: Do not try to redefine GCC builtins (we use Cosmopolitan which
+# does not have any builtins
+	sed -i -e '/^char \$$2 ()\;/s/^/\/\//' ocaml/configure
+	sed -i -e '/^return \$$2 ()\;/c\return &\$$2\;' ocaml/configure
 # configure: Allow precise input of flags and libs
-	sed -i -e 's/oc_cflags="/oc_cflags="-z caml-startup $$OC_CFLAGS /g' ocaml/configure
+	sed -i -e 's/oc_cflags="/oc_cflags="$$OC_CFLAGS /g' ocaml/configure
 	sed -i -e 's/ocamlc_cflags="/ocamlc_cflags="$$OCAMLC_CFLAGS /g' ocaml/configure
 	sed -i -e 's/nativecclibs="$$cclibs $$DLLIBS"/nativecclibs="$$GLOBAL_LIBS"/g' ocaml/configure
 # runtime/Makefile: Runtime rules: don't build libcamlrun.a and import ocamlrun from the system

--- a/toolchain/GNUmakefile
+++ b/toolchain/GNUmakefile
@@ -64,9 +64,6 @@ bin/$(CONFIG_TARGET_TRIPLE)-%: %.in | bin
 include/cosmopolitan/cosmopolitan.h: $(HEADER)
 	@echo "GEN $@"
 	@cp $< $@
-	@echo "PATCH $@"
-	@echo '' >> $@
-	@echo '#include "esperanto.h"' >> $@
 
 %.o: %.c include/cosmopolitan/cosmopolitan.h
 	$(HOSTCOMPILE.c)

--- a/toolchain/cc.in
+++ b/toolchain/cc.in
@@ -113,6 +113,15 @@ done
 
 DRIVER="cosmopolitan_syscalls.o"
 
+# XXX(dinosaure): note about [preprocesse]. Currently, we **don't** include
+# cosmopolitan.h & esperanto.h. This choice was made because
+# [domainstate.ml{,i}] was produced by a preprocesser like [cc -E]. If we
+# include our files, we generate bad files and [ocamlopt] is not able to
+# compile them then. On Ubuntu, the OCaml's [configure] recognizes [/lib/cpp]
+# as the preprocesser which is fine but, on FreeBSD, we use
+# [arch-esperanto-none-static-cc -E] (so, this script) so we must have a /well/
+# behavior for preprocessing.
+
 case ${M} in
     preprocesse)
         [ -n "${B}" ] && B="-DSUPPORT_VECTOR=${B}"
@@ -123,8 +132,6 @@ case ${M} in
 	    ${G} -O \
             -nostdlib -nostdinc \
 	    -I ${I} \
-	    -imacros cosmopolitan.h \
-	    -imacros esperanto.h \
 	    ${B} \
 	    "$@"
         ;;

--- a/toolchain/cc.in
+++ b/toolchain/cc.in
@@ -121,6 +121,8 @@ case ${M} in
 	    -fno-pie -no-pie -mno-red-zone \
             -nostdlib -nostdinc -fno-omit-frame-pointer -mno-tls-direct-seg-refs \
 	    -I ${I} \
+	    -include cosmopolitan.h \
+	    -include esperanto.h \
 	    ${B} \
 	    "$@"
         ;;
@@ -146,6 +148,8 @@ case ${M} in
 	    -Wl,--gc-sections \
             -fuse-ld=bfd -Wl,-T,${L}/ape.lds \
 	    -I ${I} \
+	    -include cosmopolitan.h \
+	    -include esperanto.h \
 	    -L ${L} \
 	    ${L}/${DRIVER} ${L}/crt.o ${L}/ape-no-modify-self.o ${L}/cosmopolitan.a
         ;;

--- a/toolchain/cc.in
+++ b/toolchain/cc.in
@@ -89,7 +89,10 @@ for arg do
 	-g)
 	    G=set
 	    ;;
-        -c|-S|-E)
+	-E)
+	    M=preprocesse
+	    ;;
+        -c|-S)
             M=compile
             ;;
         -z)
@@ -99,7 +102,7 @@ for arg do
             fi
     esac
 
-    [ "${arg##*.}" = "s" ] && A=set
+    [ "${arg##*.}" = "s" -o "${arg##*.}" = "S" ] && A=set
     [ "${arg}" = "-lunix" ] && WITH_UNIX=set
     [ "${arg}" = "-lthreads" -o "${arg}" = "-lthreadsnat" ] && WITH_THREADS=set
     # XXX(dinosaure): currently, [threadsnat] seems the more
@@ -111,18 +114,33 @@ done
 DRIVER="cosmopolitan_syscalls.o"
 
 case ${M} in
-    compile)
+    preprocesse)
         [ -n "${B}" ] && B="-DSUPPORT_VECTOR=${B}"
         [ -n "${__V}" ] && set -x
 	[ -z "${G}" -a -z "${A}" ] && G="-g" || G=
         exec @@CONFIG_TARGET_CC@@ \
             @@CONFIG_TARGET_CC_CFLAGS@@ \
 	    ${G} -O \
+            -nostdlib -nostdinc \
+	    -I ${I} \
+	    -imacros cosmopolitan.h \
+	    -imacros esperanto.h \
+	    ${B} \
+	    "$@"
+        ;;
+    compile)
+        [ -n "${B}" ] && B="-DSUPPORT_VECTOR=${B}"
+        [ -n "${__V}" ] && set -x
+	[ -z "${G}" -a -z "${A}" ] && G="-g" || G=
+	[ -z "${A}" ] && include_opt="-include" || include_opt="-imacros"
+        exec @@CONFIG_TARGET_CC@@ \
+            @@CONFIG_TARGET_CC_CFLAGS@@ \
+	    ${G} -O \
 	    -fno-pie -no-pie -mno-red-zone \
             -nostdlib -nostdinc -fno-omit-frame-pointer -mno-tls-direct-seg-refs \
 	    -I ${I} \
-	    -include cosmopolitan.h \
-	    -include esperanto.h \
+	    ${include_opt} cosmopolitan.h \
+	    ${include_opt} esperanto.h \
 	    ${B} \
 	    "$@"
         ;;

--- a/toolchain/include/cosmopolitan/arpa/inet.h
+++ b/toolchain/include/cosmopolitan/arpa/inet.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/assert.h
+++ b/toolchain/include/cosmopolitan/assert.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/ctype.h
+++ b/toolchain/include/cosmopolitan/ctype.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/dirent.h
+++ b/toolchain/include/cosmopolitan/dirent.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/endian.h
+++ b/toolchain/include/cosmopolitan/endian.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/errno.h
+++ b/toolchain/include/cosmopolitan/errno.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/esperanto.h
+++ b/toolchain/include/cosmopolitan/esperanto.h
@@ -497,7 +497,9 @@ extern ssize_t __esperanto_pwrite(int, const void *, size_t, off_t);
 // The existence of [FILE*] is checked by the definition of [__DEFINED_FILE]
 // as musl does.
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#if !defined(__clang__) // XXX(dinosaure): emit a warning with clang
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #pragma GCC diagnostic ignored "-Wredundant-decls"
 #define __DEFINED_FILE
 #undef __GNUC__

--- a/toolchain/include/cosmopolitan/esperanto.h
+++ b/toolchain/include/cosmopolitan/esperanto.h
@@ -3,6 +3,7 @@
 #define __OCAML_ESPERANTO__
 
 #pragma GCC diagnostic ignored "-Wredundant-decls"
+/* XXX(dinosaure): only for OCaml and [./configure]. */
 
 #undef SIGUSR1
 #undef SIGUSR2
@@ -489,7 +490,8 @@ extern ssize_t __esperanto_pwrite(int, const void *, size_t, off_t);
 #endif /* CAML_NAME_SPACE */
 
 // XXX(dinosaure): for [mirage-crypto]
-#pragma GCC diagnostic ignored "-Wpedantic"
+#define __MIRAGE_CRYPTO_NO_ACCELERATE__
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // XXX(dinosaure): for [ocaml-gmp]
 // Some warnings are promoted as errors due to Cosmopolitan's pragma
 // The existence of [FILE*] is checked by the definition of [__DEFINED_FILE]
@@ -498,6 +500,7 @@ extern ssize_t __esperanto_pwrite(int, const void *, size_t, off_t);
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #pragma GCC diagnostic ignored "-Wredundant-decls"
 #define __DEFINED_FILE
+#undef __GNUC__
 
 #ifndef __ESPERANTO_OFF_T__
 #define __ESPERANTO_OFF_T__

--- a/toolchain/include/cosmopolitan/esperanto.h
+++ b/toolchain/include/cosmopolitan/esperanto.h
@@ -244,13 +244,13 @@
 #define EOVERFLOW 0
 #define EUNKNOWNERR 0
 
-#if defined(HAS_WAITPID) || defined(HAS_WAIT4)
+// #if defined(HAS_WAITPID) || defined(HAS_WAIT4)
 #undef WNOHANG
 #undef WUNTRACED
 
 #define WNOHANG 0
 #define WUNTRACED 0
-#endif /* defined(HAS_WAITPID) || defined(HAS_WAIT4) */
+// #endif /* defined(HAS_WAITPID) || defined(HAS_WAIT4) */
 
 #undef SIG_SETMASK
 #undef SIG_BLOCK

--- a/toolchain/include/cosmopolitan/fcntl.h
+++ b/toolchain/include/cosmopolitan/fcntl.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/float.h
+++ b/toolchain/include/cosmopolitan/float.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/grp.h
+++ b/toolchain/include/cosmopolitan/grp.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/limits.h
+++ b/toolchain/include/cosmopolitan/limits.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/math.h
+++ b/toolchain/include/cosmopolitan/math.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/netdb.h
+++ b/toolchain/include/cosmopolitan/netdb.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/netinet/in.h
+++ b/toolchain/include/cosmopolitan/netinet/in.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/netinet/tcp.h
+++ b/toolchain/include/cosmopolitan/netinet/tcp.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/poll.h
+++ b/toolchain/include/cosmopolitan/poll.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/pwd.h
+++ b/toolchain/include/cosmopolitan/pwd.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sched.h
+++ b/toolchain/include/cosmopolitan/sched.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/setjmp.h
+++ b/toolchain/include/cosmopolitan/setjmp.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/signal.h
+++ b/toolchain/include/cosmopolitan/signal.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/stdarg.h
+++ b/toolchain/include/cosmopolitan/stdarg.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/stddef.h
+++ b/toolchain/include/cosmopolitan/stddef.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/stdint.h
+++ b/toolchain/include/cosmopolitan/stdint.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/stdio.h
+++ b/toolchain/include/cosmopolitan/stdio.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/stdlib.h
+++ b/toolchain/include/cosmopolitan/stdlib.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/string.h
+++ b/toolchain/include/cosmopolitan/string.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/strings.h
+++ b/toolchain/include/cosmopolitan/strings.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/auxv.h
+++ b/toolchain/include/cosmopolitan/sys/auxv.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/dir.h
+++ b/toolchain/include/cosmopolitan/sys/dir.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/file.h
+++ b/toolchain/include/cosmopolitan/sys/file.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/ioctl.h
+++ b/toolchain/include/cosmopolitan/sys/ioctl.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/mman.h
+++ b/toolchain/include/cosmopolitan/sys/mman.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/param.h
+++ b/toolchain/include/cosmopolitan/sys/param.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/random.h
+++ b/toolchain/include/cosmopolitan/sys/random.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/resource.h
+++ b/toolchain/include/cosmopolitan/sys/resource.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/select.h
+++ b/toolchain/include/cosmopolitan/sys/select.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/signal.h
+++ b/toolchain/include/cosmopolitan/sys/signal.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/socket.h
+++ b/toolchain/include/cosmopolitan/sys/socket.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/stat.h
+++ b/toolchain/include/cosmopolitan/sys/stat.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/time.h
+++ b/toolchain/include/cosmopolitan/sys/time.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/times.h
+++ b/toolchain/include/cosmopolitan/sys/times.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/types.h
+++ b/toolchain/include/cosmopolitan/sys/types.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/uio.h
+++ b/toolchain/include/cosmopolitan/sys/uio.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/un.h
+++ b/toolchain/include/cosmopolitan/sys/un.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/sys/wait.h
+++ b/toolchain/include/cosmopolitan/sys/wait.h
@@ -1,1 +1,0 @@
-#include "../cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/termios.h
+++ b/toolchain/include/cosmopolitan/termios.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/time.h
+++ b/toolchain/include/cosmopolitan/time.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/cosmopolitan/unistd.h
+++ b/toolchain/include/cosmopolitan/unistd.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"

--- a/toolchain/include/x86/x86intrin.h
+++ b/toolchain/include/x86/x86intrin.h
@@ -1,1 +1,0 @@
-#include "cosmopolitan.h"


### PR DESCRIPTION
This version use `-include`/`-imacros` instead of `#include` which seems better to compile third-part libraries.