### PR TITLE
Delete -mnop-mcount from the linker

### DIFF
--- a/toolchain/ld.in
+++ b/toolchain/ld.in
@@ -107,7 +107,7 @@ DRIVER=cosmopolitan_syscalls.o
   || WITH_THREADS="${L}/fake_threads.o"
 exec @@CONFIG_TARGET_LD@@ \
     ${G} -static -nostdlib \
-    -nostdlib -nostdinc -fno-omit-frame-pointer -mnop-mcount -mno-tls-direct-seg-refs \
+    -nostdlib -nostdinc -fno-omit-frame-pointer -mno-tls-direct-seg-refs \
     @@CONFIG_TARGET_LD_LDFLAGS@@ ${S} ${B} "$@" \
     -Wl,--gc-sections \
     -fuse-ld=bfd -T ${L}/ape.lds \


### PR DESCRIPTION
It seems that with `dune.3.7.0`, the build system try to compile something (like a *.h) and -mnop-mcount comes from the `ld.in` but it can be used with `-fPIC`. It's probably more a dune issue than an esperanto issue but the purpose of mnop-mcount is not really important when we don't use `-pg` option.